### PR TITLE
The 'u' format is removed in python 3.12, switch to using PyUnicode_AsWideCharString as recommended.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+onboard (1.4.1.1-deepin9) unstable; urgency=medium
+
+  * debian/patches:
+    + Add Switch-to-using-PyUnicode_AsWideCharString.patch. As the 'u' format
+      is removed in python 3.12.
+      https://github.com/dr-ni/onboard/commit/b00a15ca3bb2b92c92b03251d2438a3b07239889
+
+ -- Tianyu Chen <sweetyfish@deepin.org>  Wed, 18 Jun 2025 11:20:51 +0800
+
 onboard (1.4.1.1-deepin8) unstable; urgency=medium
 
   * update version for rebuild.

--- a/debian/patches/Switch-to-using-PyUnicode_AsWideCharString.patch
+++ b/debian/patches/Switch-to-using-PyUnicode_AsWideCharString.patch
@@ -1,0 +1,62 @@
+Description: [PATCH] The 'u' format is removed in python 3.12, switch to using
+ PyUnicode_AsWideCharString as recommended.
+Author: dr-ni <uwe_niethammer@web.de>
+Origin: upstream
+Forwarded: not-needed
+Applied-Upstream: https://github.com/dr-ni/onboard/commit/b00a15ca3bb2b92c92b03251d2438a3b07239889
+Reviewed-by: Tianyu Chen <sweetyfish@deepin.org>
+Last-Update: 2025-06-18
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/Onboard/osk/osk_module.h
++++ b/Onboard/osk/osk_module.h
+@@ -22,6 +22,8 @@
+ #ifndef __OSK_MODULE__
+ #define __OSK_MODULE__
+ 
++#define PY_SSIZE_T_CLEAN
++
+ #include <Python.h>
+ #include <structmember.h>
+ 
+--- a/Onboard/osk/osk_virtkey.c
++++ b/Onboard/osk/osk_virtkey.c
+@@ -1092,7 +1092,8 @@ virtkey_get_label_from_keysym (int keysym)
+                 else
+                 {
+                     size_t l = MIN(strlen(name), sizeof(buf)-1);
+-                    strncpy(buf, name, l);
++                    memcpy(buf, name, l);
++
+                     buf[l] = '\0';
+                     if (l > 2 && name[0] == '0' && name[1] == 'x') // hex number?
+                     {
+@@ -1461,14 +1461,23 @@ osk_virtkey_keycode_from_keysym (PyObject *self, PyObject *args)
+ static PyObject *
+ osk_virtkey_keysym_from_unicode (PyObject *self, PyObject *args)
+ {
+-    long keysym;
+-    Py_UNICODE* ucs;
++    PyObject *utf_obj;
++    wchar_t *str = NULL;
+ 
+-    if (!PyArg_ParseTuple (args, "u", &ucs))
++    if (!PyArg_ParseTuple (args, "O", &utf_obj))
+         return NULL;
+ 
+-    keysym = ucs2keysym(*ucs);
+-    return PyLong_FromLong (keysym);
++    str = PyUnicode_AsWideCharString(utf_obj, NULL);
++    if (str != NULL)
++    {
++        long keysym;
++        keysym = ucs2keysym(str[0]);
++        PyMem_Free (str);
++
++        return PyLong_FromLong (keysym);
++    }
++
++    return NULL;
+ }
+ 
+ static PyObject *

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -13,3 +13,4 @@
 2002_drop-dbus-test.patch
 1011_python-distutils-byebye.patch
 Ensure-Python-GIL-handling-in-event-handlers.patch
+Switch-to-using-PyUnicode_AsWideCharString.patch


### PR DESCRIPTION
https://github.com/dr-ni/onboard/commit/b00a15ca3bb2b92c92b03251d2438a3b07239889